### PR TITLE
Fix proxy reload issue

### DIFF
--- a/plugins/apollo-config.js
+++ b/plugins/apollo-config.js
@@ -1,11 +1,12 @@
 export default function({ app }) {
+  const backendUrl = process.BACKEND_URL || 'http://localhost:4000'
   return {
-    httpEndpoint: '/api',
+    httpEndpoint: process.server ? backendUrl : '/api',
     httpLinkOptions: {
       credentials: 'same-origin'
     },
     credentials: true,
-    tokenName: 'apollo-token',
+    tokenName: 'human-connection-token',
     persisting: false,
     websocketsOnly: false
   }


### PR DESCRIPTION
Fixes an issue whre the backend tries to access an relative path `/api` but the proxy is only active in the browser. So we give the apollo client the backend url on the server side and the `/api` proxied relative path on the server side.