### PR TITLE
Split development config from production config

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,8 +3,8 @@ version: '3.7'
 services:
   webapp:
     volumes:
-      - .:/HC-WebApp
-      - node_modules:/HC-WebApp/node_modules
+      - .:/nitro-web
+      - node_modules:/nitro-web/node_modules
     command: yarn run dev
 
 volumes:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+
+services:
+  webapp:
+    volumes:
+      - .:/HC-WebApp
+      - node_modules:/HC-WebApp/node_modules
+    command: yarn run dev
+
+volumes:
+  node_modules:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,7 +5,9 @@ services:
     volumes:
       - .:/nitro-web
       - node_modules:/nitro-web/node_modules
+      - node_modules_styleguide:/nitro-web/styleguide/node_modules
     command: yarn run dev
 
 volumes:
   node_modules:
+  node_modules_styleguide:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,13 @@ version: '3.7'
 
 services:
   webapp:
-    build:
-      context: .
+    image: humanconnection/nitro-web:latest
+    build: .
     ports:
       - 3000:3000
       - 8080:8080
     networks:
       - hc-network
-    volumes:
-      - .:/HC-WebApp
-      - node_modules:/HC-WebApp/node_modules
-    command: yarn run dev
     environment:
       - HOST=0.0.0.0
       - BACKEND_URL=http://backend:4000


### PR DESCRIPTION
in `docker-compose.yml` and `docker-compose.override.yml`. This should speed
up builds e.g. on Travis CI, which does not need to sync folders or run
`yarn run dev` if the docker image was built recently. Also it should
make the build more reliable as it behaves more similar to our deployment.