### PR TITLE
Bind name to name instead of model

### DIFF
--- a/styleguide/src/system/components/data-input/Input/Input.vue
+++ b/styleguide/src/system/components/data-input/Input/Input.vue
@@ -13,7 +13,7 @@
           iconRight && `ds-input-has-icon-right`
         ]"
         :id="id"
-        :name="model"
+        :name="name"
         :type="type"
         :autofocus="autofocus"
         :placeholder="placeholder"


### PR DESCRIPTION
Apparently this slipped through somehow in
https://github.com/Human-Connection/Nitro-Web/pull/13

Cypress won't find the email input field without this change.