### PR TITLE
No need to call xip.io anymore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     command: yarn run dev
     environment:
       - HOST=0.0.0.0
-      - BACKEND_URL=http://backend.127.0.0.1.xip.io:4000
+      - BACKEND_URL=http://backend:4000
 
 networks:
   hc-network:


### PR DESCRIPTION
After https://github.com/Human-Connection/Nitro-Backend/pull/61
the xip.io URL has become obsolete

merge after the PR above :point_up: 