### PR TITLE
Remove custom "npm link" behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ All reusable Components (for example avatar) should be done inside the [Nitro-St
 
 More information can be found here: https://github.com/Human-Connection/Nitro-Styleguide
 
-
-If you need to change something in the styleguide and want to see the effects on the frontend immediately, then we have you covered.
-You need to clone the styleguide to the parent directory `../Nitro-Styleguide` and run `yarn && yarn run dev`. After that you run `yarn run dev:styleguide` instead of `yarn run dev` and you will see your changes reflected inside the fronten!
+Use [`yarn link`](https://yarnpkg.com/lang/en/docs/cli/link/) to modify the styleguide repository locally:
+```sh
+# in Nitro-Styleguide
+$ yarn link
+$ cd ../Nitro-Web
+$ yarn link "@human-connection/styleguide"
+```
 
 ## Internationalization (i18n)
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,14 +2,6 @@ const pkg = require('./package')
 const envWhitelist = ['NODE_ENV', 'MAINTENANCE', 'MAPBOX_TOKEN']
 const dev = process.env.NODE_ENV !== 'production'
 
-const styleguidePath = '../Nitro-Styleguide'
-const styleguideStyles = process.env.STYLEGUIDE_DEV
-  ? [
-      `${styleguidePath}/src/system/styles/main.scss`,
-      `${styleguidePath}/src/system/styles/shared.scss`
-    ]
-  : '@human-connection/styleguide/dist/shared.scss'
-
 module.exports = {
   mode: 'universal',
 
@@ -78,7 +70,7 @@ module.exports = {
   ** Global processed styles
   */
   styleResources: {
-    scss: styleguideStyles
+    scss: '@human-connection/styleguide/dist/shared.scss'
   },
 
   /*
@@ -192,19 +184,6 @@ module.exports = {
           test: /\.(js|vue)$/,
           loader: 'eslint-loader',
           exclude: /(node_modules)/
-        })
-      }
-      if (process.env.STYLEGUIDE_DEV) {
-        const path = require('path')
-        config.resolve.alias['@@'] = path.resolve(
-          __dirname,
-          `${styleguidePath}/src/system`
-        )
-        config.module.rules.push({
-          resourceQuery: /blockType=docs/,
-          loader: require.resolve(
-            `${styleguidePath}/src/loader/docs-trim-loader.js`
-          )
         })
       }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "private": true,
   "scripts": {
     "dev": "cross-env NODE_ENV=development nodemon server/index.js --watch server",
-    "dev:styleguide": "cross-env STYLEGUIDE_DEV=true yarn dev",
     "build": "nuxt build",
     "start": "cross-env node server/index.js",
     "generate": "nuxt generate",

--- a/plugins/styleguide-dev.js
+++ b/plugins/styleguide-dev.js
@@ -1,4 +1,0 @@
-import Vue from 'vue'
-import Styleguide from '@@'
-
-Vue.use(Styleguide)


### PR DESCRIPTION
There is already a procedure for both npm and yarn to read an npm module
from a local folder. It's convenient and reliable.

E.g. `yarn run dev:styleguide` maybe works for in the browser. But if I
import `@humanconnection/styleguide` in the test, I get
non-deterministic behaviour.

Let's get rid of `yarn run dev:styleguide`



@appinteractive what is the command that you run before you upload to `@humanconnection/styleguide`? If I do `yarn run build:lib`, link the npm package in `Nitro-Web` I get the following error message:

```
 WARN  in ./plugins/styleguide.js                                                                                                   friendly-errors 02:08:15

"export 'default' (imported as 'Styleguide') was not found in '@human-connection/styleguide'        
```
The dropdown menu for `Report contribution` is neither visible nor clickable.

![2019-03-09-015406_1920x1080_scrot](https://user-images.githubusercontent.com/2110676/54063940-71f06280-4210-11e9-84ce-95607268e3eb.png)
