### PR TITLE
Small changes on translation mistakes - Portuguese

### DIFF
--- a/locales/pt.json
+++ b/locales/pt.json
@@ -40,11 +40,11 @@
     }
   },
   "admin": {
-    "name": "Administrator",
+    "name": "Administrador",
     "dashboard": {
       "name": "Painel de controle",
       "users": "Usuários",
-      "posts": "Pastagens",
+      "posts": "Postagens",
       "comments": "Comentários",
       "notifications": "Notificações",
       "organizations": "Organizações",
@@ -68,12 +68,12 @@
     "categories": {
       "name": "Categorias",
       "categoryName": "Nome",
-      "postCount": "Pastagens"
+      "postCount": "Postagens"
     },
     "tags": {
       "name": "Etiquetas",
       "tagCountUnique": "Usuários",
-      "tagCount": "Pastagens"
+      "tagCount": "Postagens"
     },
     "settings": {
       "name": "Configurações"
@@ -106,9 +106,9 @@
     "category": "Categoria ::: Categorias",
     "organization": "Organização ::: Organizações",
     "project": "Projeto ::: Projetos",
-    "tag": "Tag ::: Tags",
+    "tag": "Etiqueta ::: Etiquetas",
     "name": "Nome",
-    "loadMore": "carregar mais",
-    "loading": "carregando"
+    "loadMore": "Carregar mais",
+    "loading": "Carregando"
   }
 }


### PR DESCRIPTION
The translation of "post" is "postagem", and not "pastagem". Pastagem means where the cow eats grass.
The "admin" was as "Administrator", while the correct word is "Administrador".

I'm not sure about what "Shouts" are, but I don't really know if the word "Gritos" is the properly for this thing. In portuguese, when you say "Grito", the literal translation of "Shouts" you think of a person screaming, and I don't think that's was the intention. If somebody could explain me what a "Shout" means in this code I could help in a more accurate translation.