### PR TITLE
Update translations

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1,13 +1,4 @@
 {
-  "actions": {
-    "loading": "lade",
-    "loadMore": "mehr laden",
-    "create": "Erstellen",
-    "save": "Speichern",
-    "edit": "Bearbeiten",
-    "delete": "Löschen",
-    "cancel": "Abbrechen"
-  },
   "login": {
     "copy": "Wenn Du bereits ein Konto bei Human Connection hast, melde Dich bitte hier an.",
     "login": "Einloggen",
@@ -16,13 +7,6 @@
     "password": "Dein Passwort",
     "moreInfo": "Was ist Human Connection?",
     "hello": "Hallo"
-  },
-  "followButton": {
-    "follow": "Folgen",
-    "following": "Folge Ich"
-  },
-  "shoutButton": {
-    "shouted": "empfohlen"
   },
   "profile": {
     "name": "Mein Profil",
@@ -100,6 +84,48 @@
       "name": "Einstellungen"
     }
   },
+  "post": {
+    "name": "Beitrag",
+    "moreInfo": {
+      "name": "Mehr Info"
+    },
+    "takeAction": {
+      "name": "Aktiv werden"
+    }
+  },
+  "quotes": {
+    "african": {
+      "quote": "Viele kleine Leute an vielen kleinen Orten, die viele kleine Dinge tun, werden das Antlitz dieser Welt verändern.",
+      "author": "Afrikanisches Sprichwort"
+    }
+  },
+  "common": {
+    "post": "Beitrag ::: Beiträge",
+    "comment": "Kommentar ::: Kommentare",
+    "letsTalk": "Miteinander reden",
+    "versus": "Versus",
+    "moreInfo": "Mehr Info",
+    "takeAction": "Aktiv werden",
+    "shout": "Empfehlung ::: Empfehlungen",
+    "user": "Benutzer ::: Benutzer",
+    "category": "Kategorie ::: Kategorien",
+    "organization": "Organisation ::: Organisationen",
+    "project": "Projekt ::: Projekte",
+    "tag": "Tag ::: Tags",
+    "name": "Name",
+    "loadMore": "mehr laden",
+    "loading": "wird geladen",
+    "reportContent": "Melden"
+  },
+  "actions": {
+    "loading": "lade",
+    "loadMore": "mehr laden",
+    "create": "Erstellen",
+    "save": "Speichern",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "cancel": "Abbrechen"
+  },
   "moderation": {
     "name": "Moderation",
     "reports": {
@@ -107,14 +133,6 @@
       "name": "Meldungen",
       "reporter": "gemeldet von"
     }
-  },
-  "contribution": {
-    "edit": "Beitrag bearbeiten",
-    "delete": "Beitrag löschen"
-  },
-  "comment": {
-    "edit": "Kommentar bearbeiten",
-    "delete": "Kommentar löschen"
   },
   "disable": {
     "user": {
@@ -131,15 +149,6 @@
       "title": "Kommentar sperren",
       "type": "Kommentar",
       "message": "Bist du sicher, dass du den Kommentar \"<b>{name}</b>\" deaktivieren möchtest?"
-    }
-  },
-  "post": {
-    "name": "Beitrag",
-    "moreInfo": {
-      "name": "Mehr Info"
-    },
-    "takeAction": {
-      "name": "Aktiv werden"
     }
   },
   "report": {
@@ -161,28 +170,19 @@
       "message": "Bist du sicher, dass du den Kommentar von \"<b>{name}</b>\" melden möchtest?"
     }
   },
-  "quotes": {
-    "african": {
-      "quote": "Viele kleine Leute, an vielen kleinen Orten, die viele kleine Dinge tun, werden das Antlitz dieser Welt verändern.",
-      "author": "Afrikanisches Sprichwort"
-    }
+  "contribution": {
+    "edit": "Beitrag bearbeiten",
+    "delete": "Beitrag löschen"
   },
-  "common": {
-    "reportContent": "Melden",
-    "post": "Beitrag ::: Beiträge",
-    "comment": "Kommentar ::: Kommentare",
-    "letsTalk": "Miteinander reden",
-    "versus": "Versus",
-    "moreInfo": "Mehr Info",
-    "takeAction": "Aktiv werden",
-    "shout": "Empfehlung ::: Empfehlungen",
-    "user": "Benutzer ::: Benutzer",
-    "category": "Kategorie ::: Kategorien",
-    "organization": "Organisation ::: Organisationen",
-    "project": "Projekt ::: Projekte",
-    "tag": "Tag ::: Tags",
-    "name": "Name",
-    "loadMore": "mehr laden",
-    "loading": "wird geladen"
+  "comment": {
+    "edit": "Kommentar bearbeiten",
+    "delete": "Kommentar löschen"
+  },
+  "followButton": {
+    "follow": "Folgen",
+    "following": "Folge Ich"
+  },
+  "shoutButton": {
+    "shouted": "empfohlen"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,13 +1,4 @@
 {
-  "actions": {
-    "loading": "loading",
-    "loadMore": "load more",
-    "create": "Create",
-    "save": "Save",
-    "edit": "Edit",
-    "delete": "Delete",
-    "cancel": "Cancel"
-  },
   "login": {
     "copy": "If you already have a human-connection account, login here.",
     "login": "Login",
@@ -16,13 +7,6 @@
     "password": "Your Password",
     "moreInfo": "What is Human Connection?",
     "hello": "Hello"
-  },
-  "followButton": {
-    "follow": "Follow",
-    "following": "Following"
-  },
-  "shoutButton": {
-    "shouted": "shouted"
   },
   "profile": {
     "name": "My Profile",
@@ -100,6 +84,48 @@
       "name": "Settings"
     }
   },
+  "post": {
+    "name": "Post",
+    "moreInfo": {
+      "name": "More info"
+    },
+    "takeAction": {
+      "name": "Take action"
+    }
+  },
+  "quotes": {
+    "african": {
+      "quote": "Many small people in many small places do many small things, that can alter the face of the world.",
+      "author": "African proverb"
+    }
+  },
+  "common": {
+    "post": "Post ::: Posts",
+    "comment": "Comment ::: Comments",
+    "letsTalk": "Let`s Talk",
+    "versus": "Versus",
+    "moreInfo": "More Info",
+    "takeAction": "Take Action",
+    "shout": "Shout ::: Shouts",
+    "user": "User ::: Users",
+    "category": "Category ::: Categories",
+    "organization": "Organization ::: Organizations",
+    "project": "Project ::: Projects",
+    "tag": "Tag ::: Tags",
+    "name": "Name",
+    "loadMore": "load more",
+    "loading": "loading",
+    "reportContent": "Report"
+  },
+  "actions": {
+    "loading": "loading",
+    "loadMore": "load more",
+    "create": "Create",
+    "save": "Save",
+    "edit": "Edit",
+    "delete": "Delete",
+    "cancel": "Cancel"
+  },
   "moderation": {
     "name": "Moderation",
     "reports": {
@@ -107,14 +133,6 @@
       "name": "Reports",
       "reporter": "reported by"
     }
-  },
-  "contribution": {
-    "edit": "Edit Contribution",
-    "delete": "Delete Contribution"
-  },
-  "comment": {
-    "edit": "Edit Comment",
-    "delete": "Delete Comment"
   },
   "disable": {
     "user": {
@@ -131,15 +149,6 @@
       "title": "Disable Comment",
       "type": "Comment",
       "message": "Do you really want to disable the comment from \"<b>{name}</b>\"?"
-    }
-  },
-  "post": {
-    "name": "Post",
-    "moreInfo": {
-      "name": "More info"
-    },
-    "takeAction": {
-      "name": "Take action"
     }
   },
   "report": {
@@ -161,28 +170,19 @@
       "message": "Do you really want to report the comment from \"<b>{name}</b>\"?"
     }
   },
-  "quotes": {
-    "african": {
-      "quote": "Many small people in many small places do many small things, that can alter the face of the world.",
-      "author": "African proverb"
-    }
+  "contribution": {
+    "edit": "Edit Contribution",
+    "delete": "Delete Contribution"
   },
-  "common": {
-    "reportContent": "Report",
-    "post": "Post ::: Posts",
-    "comment": "Comment ::: Comments",
-    "letsTalk": "Let`s Talk",
-    "versus": "Versus",
-    "moreInfo": "More Info",
-    "takeAction": "Take Action",
-    "shout": "Shout ::: Shouts",
-    "user": "User ::: Users",
-    "category": "Category ::: Categories",
-    "organization": "Organization ::: Organizations",
-    "project": "Project ::: Projects",
-    "tag": "Tag ::: Tags",
-    "name": "Name",
-    "loadMore": "load more",
-    "loading": "loading"
+  "comment": {
+    "edit": "Edit Comment",
+    "delete": "Delete Comment"
+  },
+  "followButton": {
+    "follow": "Follow",
+    "following": "Following"
+  },
+  "shoutButton": {
+    "shouted": "shouted"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -13,7 +13,9 @@
     "memberSince": "Miembro desde",
     "follow": "Seguir",
     "followers": "Seguidores",
-    "following": "Siguiendo"
+    "following": "Siguiendo",
+    "shouted": "Gritar",
+    "commented": "Comentado"
   },
   "settings": {
     "name": "Configuración",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3,7 +3,7 @@
     "copy": "Si vous avez déjà un compte human-connection, connectez-vous ici.",
     "login": "Connexion",
     "logout": "Déconnexion",
-    "email": "Votre Message électronique",
+    "email": "Votre courriel",
     "password": "Votre mot de passe",
     "moreInfo": "Qu'est-ce que Human Connection?",
     "hello": "Bonjour"
@@ -109,6 +109,61 @@
     "tag": "Tag ::: Tags",
     "name": "Nom",
     "loadMore": "charger plus",
-    "loading": "chargement"
+    "loading": "chargement",
+    "reportContent": "Signaler"
+  },
+  "moderation": {
+    "reports": {
+      "empty": "Félicitations, rien à modérer.",
+      "name": "Signalisations",
+      "reporter": "signalé par"
+    }
+  },
+  "disable": {
+    "user": {
+      "title": "Désactiver l'utilisateur",
+      "type": "Utilisateur",
+      "message": "Souhaitez-vous vraiment désactiver l'utilisateur \" <b> {name} </b> \"?"
+    },
+    "contribution": {
+      "title": "Désactiver l'apport",
+      "type": "apport",
+      "message": "Souhaitez-vous vraiment signaler l'entrée\" <b> {name} </b> \"?"
+    },
+    "comment": {
+      "title": "Désactiver le commentaire",
+      "type": "Commentaire",
+      "message": "Souhaitez-vous vraiment désactiver le commentaire de \"<b>{nom}</b>\" ?"
+    }
+  },
+  "report": {
+    "submit": "Envoyer le rapport",
+    "cancel": "Annuler",
+    "user": {
+      "title": "Signaler l'utilisateur",
+      "type": "Utilisateur",
+      "message": "Souhaitez-vous vraiment signaler l'utilisateur \" <b> {name} </b> \"?"
+    },
+    "contribution": {
+      "title": "Signaler l'entrée",
+      "type": "Apport",
+      "message": "Souhaitez-vous vraiment signaler l'entrée\" <b> {name} </b> \"?"
+    },
+    "comment": {
+      "title": "Signaler un commentaire",
+      "type": "Commentaire",
+      "message": "Souhaitez-vous vraiment signaler l'utilisateur \" <b> {name} </b> \"?"
+    }
+  },
+  "actions": {
+    "cancel": "Annuler"
+  },
+  "contribution": {
+    "edit": "Rédiger l'apport",
+    "delete": "Supprimer l'entrée"
+  },
+  "comment": {
+    "edit": "Rédiger un commentaire",
+    "delete": "Supprimer le commentaire"
   }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -1,6 +1,6 @@
 {
   "login": {
-    "copy": "Se hai già un account di Human Connection, accedi qui.",
+    "copy": "Se sei gia registrato su Human Connection, accedi qui.",
     "login": "Accesso",
     "logout": "Logout",
     "email": "La tua email",
@@ -12,13 +12,18 @@
     "name": "Il mio profilo",
     "memberSince": "Membro dal",
     "follow": "Seguire",
-    "followers": "Seguaci",
-    "following": "Seguendo"
+    "followers": "Seguenti",
+    "following": "Seguendo",
+    "shouted": "Gridato",
+    "commented": "Commentato"
   },
   "settings": {
     "name": "Impostazioni",
     "data": {
-      "name": "I tuoi dati"
+      "name": "I tuoi dati",
+      "labelName": "Nome",
+      "labelCity": "La tua città o regione",
+      "labelBio": "Su di te"
     },
     "security": {
       "name": "Sicurezza"
@@ -27,7 +32,7 @@
       "name": "Inviti"
     },
     "download": {
-      "name": "Scaricare i dati"
+      "name": "Scaricamento dati"
     },
     "delete": {
       "name": "Elimina Account"
@@ -51,7 +56,7 @@
       "projects": "Progetti",
       "invites": "Inviti",
       "follows": "Segue",
-      "shouts": "Grida"
+      "shouts": "Gridi"
     },
     "organizations": {
       "name": "Organizzazioni"
@@ -90,25 +95,33 @@
   },
   "quotes": {
     "african": {
-      "quote": "Molte piccole persone in molti piccoli luoghi fanno molte piccole cose, che possono alterare la faccia del mondo.",
+      "quote": "Molte piccole persone in molti piccoli luoghi fanno molte piccole cose, che possono cambiare la faccia del mondo.",
       "author": "Proverbio africano"
     }
   },
   "common": {
     "post": "Messaggio ::: Messaggi",
     "comment": "Commento ::: Commenti",
-    "letsTalk": "Parliamo",
-    "versus": "Contro",
+    "letsTalk": "Discutiamo",
+    "versus": "Verso",
     "moreInfo": "Ulteriori informazioni",
     "takeAction": "Agire",
-    "shout": "Grida ::: Grida",
+    "shout": "Grido ::: Gridi",
     "user": "Utente ::: Utenti",
     "category": "Categoria ::: Categorie",
     "organization": "Organizzazione ::: Organizzazioni",
     "project": "Progetto ::: Progetti",
     "tag": "Tag ::: Tag",
     "name": "Nome",
-    "loadMore": "caricare di più",
-    "loading": "caricamento"
+    "loadMore": "Caricare di più",
+    "loading": "Caricamento in corso"
+  },
+  "actions": {
+    "loading": "Caricamento in corso",
+    "loadMore": "Carica di più",
+    "create": "Crea",
+    "save": "Salva",
+    "edit": "Modifica",
+    "delete": "Cancella"
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -109,6 +109,51 @@
     "tag": "Tag ::: Tags",
     "name": "Naam",
     "loadMore": "meer laden",
-    "loading": "inlading"
+    "loading": "inlading",
+    "reportContent": "Melden"
+  },
+  "disable": {
+    "comment": {
+      "title": "Commentaar uitschakelen",
+      "type": "Melding",
+      "message": "Wilt u de reactie van \" <b> {name} </b> \" echt uitschakelen ?"
+    }
+  },
+  "report": {
+    "submit": "Verzenden",
+    "cancel": "Annuleren",
+    "user": {
+      "title": "Gebruiker melden",
+      "type": "Gebruiker",
+      "message": "Wilt u echt het commentaar van \"<b>{name}</b>\" melden?"
+    },
+    "contribution": {
+      "title": "Bijdrage melden",
+      "type": "Bijdrage",
+      "message": "Wilt u echt het commentaar van \"<b>{name}</b>\" melden?"
+    },
+    "comment": {
+      "title": "Reactie melden",
+      "type": "Melding",
+      "message": "Wilt u echt het commentaar van \"<b>{name}</b>\" melden?"
+    }
+  },
+  "actions": {
+    "cancel": "Annuleren"
+  },
+  "contribution": {
+    "edit": "Bijdrage bewerken",
+    "delete": "Bijdrage verwijderen"
+  },
+  "comment": {
+    "edit": "Commentaar bewerken",
+    "delete": "Commentaar verwijderen"
+  },
+  "followButton": {
+    "follow": "Volgen",
+    "following": "Volgt"
+  },
+  "shoutButton": {
+    "shouted": "uitgeroepen"
   }
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -13,12 +13,17 @@
     "memberSince": "Członek od",
     "follow": "Obserwuj",
     "followers": "Obserwujący",
-    "following": "Obserwowani"
+    "following": "Obserwowani",
+    "shouted": "Krzyknij",
+    "commented": "Skomentuj"
   },
   "settings": {
     "name": "Ustawienia",
     "data": {
-      "name": "Twoje dane"
+      "name": "Twoje dane",
+      "labelName": "Twoje dane",
+      "labelCity": "Twoje miasto lub region",
+      "labelBio": "O Tobie"
     },
     "security": {
       "name": "Bezpieczeństwo"
@@ -109,6 +114,75 @@
     "tag": "Tag ::: Tagi",
     "name": "imię",
     "loadMore": "załaduj więcej",
-    "loading": "ładowanie"
+    "loading": "ładowanie",
+    "reportContent": "Raport"
+  },
+  "actions": {
+    "loading": "ładowanie",
+    "loadMore": "załaduj więcej",
+    "create": "Stwórz",
+    "save": "Zapisz",
+    "edit": "Edytuj",
+    "delete": "Usuń",
+    "cancel": "Anuluj"
+  },
+  "moderation": {
+    "name": "Moderacja",
+    "reports": {
+      "empty": "Gratulacje, moderacja nie jest potrzebna",
+      "name": "Raporty",
+      "reporter": "zgłoszone przez"
+    }
+  },
+  "disable": {
+    "user": {
+      "title": "Ukryj użytkownika",
+      "type": "Użytkownik",
+      "message": "Czy na pewno chcesz wyłączyć użytkownika \" <b> {name} </b> \"?"
+    },
+    "contribution": {
+      "title": "Ukryj wpis",
+      "type": "Wpis / Post",
+      "message": "Czy na pewno chcesz ukryć wpis \" <b> tytuł} </b> \"?"
+    },
+    "comment": {
+      "title": "Ukryj wpis",
+      "type": "Komentarz",
+      "message": "Czy na pewno chcesz ukryć komentarz użytkownika\"<b>(Imie/Avatar</b>\"?"
+    }
+  },
+  "report": {
+    "submit": "Wyślij raport",
+    "cancel": "Anuluj",
+    "user": {
+      "title": "Zgłoś użytkownika",
+      "type": "Użytkownik",
+      "message": "Czy na pewno chcesz zgłosić użytkownika \" <b> {Imie} </b> \"?"
+    },
+    "contribution": {
+      "title": "Zgłoś wpis",
+      "type": "Wpis / Post",
+      "message": "Czy na pewno chcesz zgłosić ten wpis użytkownika \" <b> {Imie} </b> \"?"
+    },
+    "comment": {
+      "title": "Zgłoś komentarz",
+      "type": "Komentarz",
+      "message": "Czy na pewno chcesz zgłosić komentarz użytkownika\"<b>(Imie/Avatar</b>\"?"
+    }
+  },
+  "contribution": {
+    "edit": "Edytuj wpis",
+    "delete": "Usuń wpis"
+  },
+  "comment": {
+    "edit": "Edytuj komentarz",
+    "delete": "Usuń komentarz"
+  },
+  "followButton": {
+    "follow": "Obserwuj ",
+    "following": "Obserwowani "
+  },
+  "shoutButton": {
+    "shouted": "krzyczeć"
   }
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -109,6 +109,29 @@
     "tag": "Tag ::: Tags",
     "name": "Nome",
     "loadMore": "carregar mais",
-    "loading": "carregando"
+    "loading": "carregando",
+    "reportContent": "Denunciar"
+  },
+  "report": {
+    "contribution": {
+      "title": "Denunciar Contribuição",
+      "type": "Contribuição"
+    },
+    "comment": {
+      "title": "Denunciar Comentário",
+      "type": "Comentário",
+      "message": "Realmente quer denunciar o comentário de \"<b>{nome}</b>\"?"
+    }
+  },
+  "actions": {
+    "cancel": "Cancelar"
+  },
+  "contribution": {
+    "edit": "Editar Contribuição",
+    "delete": "Apagar Contribuição"
+  },
+  "comment": {
+    "edit": "Editar Comentário",
+    "delete": "Apagar Comentário"
   }
 }


### PR DESCRIPTION
@victorrms2 have a look!


@appinteractive @mattwr18 @Tirokk I did the following steps:

1. Upload current translations for `en` and `de` to lokalise.co
  * this did not update or create any keys, instead
    all keys were skipped (apparently already there)
2. Download the translations on lokalise with the following settings:
  * ICU message with numeric pluralization
  * Don't escape forward slashes
  * Indent with 2 spaces

Here is a screenshot with the relevant settings: 
![Screenshot (36)](https://user-images.githubusercontent.com/2110676/54077686-5e023a80-42bc-11e9-97f0-f5c5eb851ba0.png)

As a follow up I also uploaded the new translations by @victorrms2 (+7 updated keys)
